### PR TITLE
Event's date is now validated to always be either the current date or in the future 

### DIFF
--- a/src/main/java/fi/asteriski/nakitin/dto/EventForm.java
+++ b/src/main/java/fi/asteriski/nakitin/dto/EventForm.java
@@ -4,6 +4,7 @@ Licenced under EUPL-1.2 or later.
  */
 package fi.asteriski.nakitin.dto;
 
+import fi.asteriski.nakitin.validation.DateMustBeInTheFuture;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -28,6 +29,7 @@ public class EventForm {
     private String description;
 
     @NotNull(message = "Ajankohta täytyy antaa")
+    @DateMustBeInTheFuture(message = "Tapahtumapäivän tulee olla tulevaisuudessa")
     private LocalDate date;
 
     @NotBlank(message = "Järjestäjä on pakollinen tieto")

--- a/src/main/java/fi/asteriski/nakitin/validation/DateMustBeInTheFuture.java
+++ b/src/main/java/fi/asteriski/nakitin/validation/DateMustBeInTheFuture.java
@@ -1,0 +1,24 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.validation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = DateMustBeInTheFutureValidator.class)
+public @interface DateMustBeInTheFuture {
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/fi/asteriski/nakitin/validation/DateMustBeInTheFutureValidator.java
+++ b/src/main/java/fi/asteriski/nakitin/validation/DateMustBeInTheFutureValidator.java
@@ -1,0 +1,17 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.time.LocalDate;
+
+public class DateMustBeInTheFutureValidator implements ConstraintValidator<DateMustBeInTheFuture, LocalDate> {
+
+    @Override
+    public boolean isValid(LocalDate value, ConstraintValidatorContext context) {
+        return value != null && !value.isBefore(LocalDate.now());
+    }
+}


### PR DESCRIPTION
 Event's date is now validated to always be either the current date or  in the future