### PR TITLE
Add email verifying on signup and on change

### DIFF
--- a/src/main/java/fi/asteriski/nakitin/config/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/fi/asteriski/nakitin/config/CustomAuthenticationFailureHandler.java
@@ -12,14 +12,13 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
 @AllArgsConstructor
 public class CustomAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
     private final RateLimitService rateLimitService;
@@ -33,10 +32,17 @@ public class CustomAuthenticationFailureHandler extends SimpleUrlAuthenticationF
         var ip = request.getRemoteAddr();
         boolean canTry = rateLimitService.tryConsumeLimitByIp(ip);
 
-        var errorMessage = messageSource.getMessage(
-                canTry ? "auth.error.invalid.credentials" : "auth.error.too.many.attempts", null, request.getLocale());
+        String redirectUrl;
+        if (!canTry) {
+            var errorMessage = messageSource.getMessage("auth.error.too.many.attempts", null, request.getLocale());
+            redirectUrl = "/login?error=true&message=" + URLEncoder.encode(errorMessage, StandardCharsets.UTF_8);
+        } else if (exception instanceof DisabledException) {
+            redirectUrl = "/login?error=disabled";
+        } else {
+            var errorMessage = messageSource.getMessage("auth.error.invalid.credentials", null, request.getLocale());
+            redirectUrl = "/login?error=true&message=" + URLEncoder.encode(errorMessage, StandardCharsets.UTF_8);
+        }
 
-        var redirectUrl = "/login?error=true&message=" + URLEncoder.encode(errorMessage, StandardCharsets.UTF_8);
         super.setDefaultFailureUrl(redirectUrl);
         super.onAuthenticationFailure(request, response, exception);
     }

--- a/src/main/java/fi/asteriski/nakitin/config/SecurityConfig.java
+++ b/src/main/java/fi/asteriski/nakitin/config/SecurityConfig.java
@@ -7,16 +7,20 @@ package fi.asteriski.nakitin.config;
 import static fi.asteriski.nakitin.entity.UserRole.*;
 import static org.springframework.http.HttpMethod.*;
 
+import fi.asteriski.nakitin.entity.UserEntity;
 import fi.asteriski.nakitin.service.UserService;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -29,6 +33,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
     private final UserService userService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final MessageSource messageSource;
 
     @Profile({"dev", "special"})
     public static class DevSecurityConfig {
@@ -99,7 +104,9 @@ public class SecurityConfig {
                                     "/favicon.ico",
                                     "/forgot-password",
                                     "/reset-password/**",
-                                    "/css/**")
+                                    "/css/**",
+                                    "/verify-email/**",
+                                    "/resend-verification/**")
                             .permitAll())
                     .formLogin(form -> form.loginPage("/login")
                             .failureHandler(authenticationFailureHandler)
@@ -117,14 +124,19 @@ public class SecurityConfig {
         }
     }
 
-    /**
-     * Configures to use custom service for user management and password encrypting method.
-     *
-     * @param auth Builtin AuthenticationManagerBuilder entity.
-     * @throws Exception
-     */
-    @Autowired
-    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(userService).passwordEncoder(bCryptPasswordEncoder);
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        var provider = new DaoAuthenticationProvider();
+        provider.setPreAuthenticationChecks(userDetails -> {
+            var user = (UserEntity) userDetails;
+            if (!user.isEmailVerified()) {
+                throw new DisabledException(messageSource.getMessage(
+                        "auth.error.email.not.verified", null, LocaleContextHolder.getLocale()));
+            }
+        });
+
+        provider.setUserDetailsService(userService);
+        provider.setPasswordEncoder(bCryptPasswordEncoder);
+        return provider;
     }
 }

--- a/src/main/java/fi/asteriski/nakitin/config/WebConfig.java
+++ b/src/main/java/fi/asteriski/nakitin/config/WebConfig.java
@@ -6,9 +6,11 @@ package fi.asteriski.nakitin.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @Configuration
+@EnableScheduling
 public class WebConfig {
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {

--- a/src/main/java/fi/asteriski/nakitin/controller/UserController.java
+++ b/src/main/java/fi/asteriski/nakitin/controller/UserController.java
@@ -11,6 +11,7 @@ import fi.asteriski.nakitin.dto.SignupForm;
 import fi.asteriski.nakitin.dto.UserDto;
 import fi.asteriski.nakitin.entity.UserEntity;
 import fi.asteriski.nakitin.service.*;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.Locale;
 import java.util.Objects;
@@ -51,14 +52,15 @@ public class UserController {
     public String signUp(
             @Validated @ModelAttribute(MODEL_LABEL_SIGNUP_FORM) SignupForm signupForm,
             BindingResult result,
-            Model model) {
+            Model model,
+            HttpServletRequest request) {
         model.addAttribute(MODEL_LABEL_SIGNUP_FORM, signupForm);
         model.addAttribute(MODEL_LABEL_USER_IS_LOGGED_IN, false);
         if (result.hasErrors()) {
             addCustomErrorIfNeeded(result, model);
             return "signup";
         }
-        userService.createNewUser(signupForm);
+        userService.createNewUser(signupForm, request);
 
         return "redirect:/success?from=signup";
     }
@@ -83,7 +85,8 @@ public class UserController {
             @Valid @ModelAttribute(MODEL_LABEL_USER_DTO) UserDto userDto,
             BindingResult result,
             @AuthenticationPrincipal UserEntity user,
-            Model model) {
+            Model model,
+            HttpServletRequest request) {
         if (result.hasErrors()) {
             setCommonUserAttributes(model, user);
             model.addAttribute(
@@ -94,7 +97,7 @@ public class UserController {
             return "profile";
         }
         userDto.setId(user.getId());
-        userService.updateUser(userDto);
+        userService.updateUser(userDto, request);
 
         return "redirect:/profile?success=true";
     }
@@ -178,12 +181,20 @@ public class UserController {
             @RequestParam(required = false) String error,
             @RequestParam(required = false) String logout,
             @RequestParam(required = false) String reset,
+            @RequestParam(required = false) String verificationSent,
             Model model,
             Locale locale) {
 
         if (error != null) {
-            model.addAttribute(
-                    MODEL_LABEL_ERROR, messageSource.getMessage("auth.error.invalid.credentials", null, locale));
+            if ("disabled".equals(error)) {
+                // Don't set MODEL_LABEL_ERROR here as it would override the template's handling
+            } else if ("locked".equals(error)) {
+                model.addAttribute(
+                        MODEL_LABEL_ERROR, messageSource.getMessage("auth.error.account.locked", null, locale));
+            } else {
+                model.addAttribute(
+                        MODEL_LABEL_ERROR, messageSource.getMessage("auth.error.invalid.credentials", null, locale));
+            }
         }
         if (logout != null) {
             model.addAttribute(

--- a/src/main/java/fi/asteriski/nakitin/controller/UserController.java
+++ b/src/main/java/fi/asteriski/nakitin/controller/UserController.java
@@ -66,7 +66,8 @@ public class UserController {
     }
 
     @GetMapping("/profile")
-    public String profile(Model model, @AuthenticationPrincipal UserEntity loggedInUser, Boolean success) {
+    public String profile(
+            Model model, @AuthenticationPrincipal UserEntity loggedInUser, Boolean success, Boolean verify) {
         setCommonUserAttributes(model, loggedInUser);
         var user = userService.fetchUserDetails(loggedInUser.getId());
         model.addAttribute(
@@ -76,6 +77,7 @@ public class UserController {
         model.addAttribute(MODEL_LABEL_USER_DTO, user);
         model.addAttribute(MODEL_LABEL_SUCCESS, success);
         model.addAttribute(MODEL_LABEL_FAILED, false);
+        model.addAttribute("verify", verify);
 
         return "profile";
     }
@@ -97,9 +99,9 @@ public class UserController {
             return "profile";
         }
         userDto.setId(user.getId());
-        userService.updateUser(userDto, request);
+        var emailChanged = userService.updateUser(userDto, request);
 
-        return "redirect:/profile?success=true";
+        return "redirect:/profile?success=true&verify=%s".formatted(emailChanged);
     }
 
     @GetMapping("/forgot-password")
@@ -181,7 +183,6 @@ public class UserController {
             @RequestParam(required = false) String error,
             @RequestParam(required = false) String logout,
             @RequestParam(required = false) String reset,
-            @RequestParam(required = false) String verificationSent,
             Model model,
             Locale locale) {
 

--- a/src/main/java/fi/asteriski/nakitin/controller/VerificationController.java
+++ b/src/main/java/fi/asteriski/nakitin/controller/VerificationController.java
@@ -4,9 +4,14 @@ Licenced under EUPL-1.2 or later.
  */
 package fi.asteriski.nakitin.controller;
 
+import static fi.asteriski.nakitin.utils.Constants.MODEL_LABEL_MESSAGE;
+import static fi.asteriski.nakitin.utils.Constants.MODEL_LABEL_SUCCESS;
+
 import fi.asteriski.nakitin.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,20 +19,26 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class VerificationController {
     private final UserService userService;
+    private final MessageSource messageSource;
 
     @GetMapping("/verify-email")
     public String verifyEmail(@RequestParam String token, Model model) {
         var result = userService.verifyEmail(token);
+        model.addAttribute("verificationStatus", result.status());
 
         if (result.verified()) {
-            model.addAttribute("success", true);
-            model.addAttribute("message", "Sähköpostiosoite vahvistettu onnistuneesti! Voit nyt kirjautua sisään.");
+            model.addAttribute(MODEL_LABEL_SUCCESS, true);
+            model.addAttribute(
+                    MODEL_LABEL_MESSAGE,
+                    messageSource.getMessage("verification.success.message", null, LocaleContextHolder.getLocale()));
         } else {
-            model.addAttribute("success", false);
-            model.addAttribute("message", "Vahvistuslinkki on vanhentunut. Ole hyvä ja pyydä uusi.");
+            model.addAttribute(MODEL_LABEL_SUCCESS, false);
+            model.addAttribute(
+                    MODEL_LABEL_MESSAGE,
+                    messageSource.getMessage("verification.error.expired", null, LocaleContextHolder.getLocale()));
             model.addAttribute("email", result.email());
         }
 

--- a/src/main/java/fi/asteriski/nakitin/controller/VerificationController.java
+++ b/src/main/java/fi/asteriski/nakitin/controller/VerificationController.java
@@ -1,0 +1,42 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.controller;
+
+import fi.asteriski.nakitin.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+public class VerificationController {
+    private final UserService userService;
+
+    @GetMapping("/verify-email")
+    public String verifyEmail(@RequestParam String token, Model model) {
+        var result = userService.verifyEmail(token);
+
+        if (result.verified()) {
+            model.addAttribute("success", true);
+            model.addAttribute("message", "Sähköpostiosoite vahvistettu onnistuneesti! Voit nyt kirjautua sisään.");
+        } else {
+            model.addAttribute("success", false);
+            model.addAttribute("message", "Vahvistuslinkki on vanhentunut. Ole hyvä ja pyydä uusi.");
+            model.addAttribute("email", result.email());
+        }
+
+        return "auth/verification-result";
+    }
+
+    @PostMapping("/resend-verification")
+    public String resendVerification(@RequestParam String email, HttpServletRequest request) {
+        userService.findByEmail(email).ifPresent(user -> userService.setupEmailVerification(user, request));
+        return "redirect:/login?verificationSent=true";
+    }
+}

--- a/src/main/java/fi/asteriski/nakitin/dao/PasswordResetTokenDao.java
+++ b/src/main/java/fi/asteriski/nakitin/dao/PasswordResetTokenDao.java
@@ -6,6 +6,8 @@ package fi.asteriski.nakitin.dao;
 
 import fi.asteriski.nakitin.entity.PasswordResetToken;
 import fi.asteriski.nakitin.repo.PasswordResetTokenRepository;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -24,5 +26,13 @@ public class PasswordResetTokenDao {
 
     public void delete(PasswordResetToken passwordResetToken) {
         passwordResetTokenRepository.delete(passwordResetToken);
+    }
+
+    public List<PasswordResetToken> findExpiredTokens() {
+        return passwordResetTokenRepository.findAllByExpiryDateIsBefore(LocalDateTime.now());
+    }
+
+    public void deleteAll(List<PasswordResetToken> toDelete) {
+        passwordResetTokenRepository.deleteAll(toDelete);
     }
 }

--- a/src/main/java/fi/asteriski/nakitin/dao/UserDao.java
+++ b/src/main/java/fi/asteriski/nakitin/dao/UserDao.java
@@ -138,4 +138,8 @@ public class UserDao {
     public void deleteUsersById(List<UUID> toDelete) {
         userRepository.deleteUsersById(toDelete);
     }
+
+    public Optional<UserEntity> findByVerificationToken(String token) {
+        return userRepository.findByVerificationToken_Token(token);
+    }
 }

--- a/src/main/java/fi/asteriski/nakitin/dao/UserDao.java
+++ b/src/main/java/fi/asteriski/nakitin/dao/UserDao.java
@@ -13,8 +13,6 @@ import fi.asteriski.nakitin.dto.admin.UserInfoForm;
 import fi.asteriski.nakitin.entity.OrganizationEntity;
 import fi.asteriski.nakitin.entity.UserEntity;
 import fi.asteriski.nakitin.repo.UserRepository;
-import fi.asteriski.nakitin.repo.projection.IdProjection;
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -135,18 +133,6 @@ public class UserDao {
 
     public Optional<UserEntity> findByEmail(String email) {
         return userRepository.findByEmail(email);
-    }
-
-    public Optional<UserEntity> findByVerificationToken(String token) {
-        return userRepository.findByVerificationToken(token);
-    }
-
-    public List<UUID> findUnverifiedUsersWithExpiredTokens() {
-        return userRepository
-                .findAllByVerificationTokenExpiryBeforeAndEmailVerifiedIsFalse(LocalDateTime.now())
-                .stream()
-                .map(IdProjection::getId)
-                .toList();
     }
 
     public void deleteUsersById(List<UUID> toDelete) {

--- a/src/main/java/fi/asteriski/nakitin/dao/UserDao.java
+++ b/src/main/java/fi/asteriski/nakitin/dao/UserDao.java
@@ -12,8 +12,9 @@ import fi.asteriski.nakitin.dto.UserDto;
 import fi.asteriski.nakitin.dto.admin.UserInfoForm;
 import fi.asteriski.nakitin.entity.OrganizationEntity;
 import fi.asteriski.nakitin.entity.UserEntity;
-import fi.asteriski.nakitin.exceptions.InvalidVerificationTokenException;
 import fi.asteriski.nakitin.repo.UserRepository;
+import fi.asteriski.nakitin.repo.projection.IdProjection;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -136,9 +137,19 @@ public class UserDao {
         return userRepository.findByEmail(email);
     }
 
-    public UserEntity findByVerificationToken(String token) {
+    public Optional<UserEntity> findByVerificationToken(String token) {
+        return userRepository.findByVerificationToken(token);
+    }
+
+    public List<UUID> findUnverifiedUsersWithExpiredTokens() {
         return userRepository
-                .findByVerificationToken(token)
-                .orElseThrow(() -> new InvalidVerificationTokenException("Invalid verification token"));
+                .findAllByVerificationTokenExpiryBeforeAndEmailVerifiedIsFalse(LocalDateTime.now())
+                .stream()
+                .map(IdProjection::getId)
+                .toList();
+    }
+
+    public void deleteUsersById(List<UUID> toDelete) {
+        userRepository.deleteUsersById(toDelete);
     }
 }

--- a/src/main/java/fi/asteriski/nakitin/dao/UserDao.java
+++ b/src/main/java/fi/asteriski/nakitin/dao/UserDao.java
@@ -12,39 +12,20 @@ import fi.asteriski.nakitin.dto.UserDto;
 import fi.asteriski.nakitin.dto.admin.UserInfoForm;
 import fi.asteriski.nakitin.entity.OrganizationEntity;
 import fi.asteriski.nakitin.entity.UserEntity;
-import fi.asteriski.nakitin.entity.UserRole;
+import fi.asteriski.nakitin.exceptions.InvalidVerificationTokenException;
 import fi.asteriski.nakitin.repo.UserRepository;
-import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class UserDao {
-    @NonNull
     private final UserRepository userRepository;
-
-    @Value("${fi.asteriski.config.maxPasswordAgeInDays}")
-    private Long maxPasswordAgeInDays;
-
-    public UserEntity saveNewUser(UserDto dto) {
-        return userRepository.save(UserEntity.builder()
-                .username(dto.getUsername())
-                .email(dto.getEmail())
-                .password(dto.getPassword())
-                .firstName(dto.getFirstName())
-                .lastName(dto.getLastName())
-                .userRole(UserRole.ROLE_USER)
-                .expirationDate(LocalDate.now().plusDays(maxPasswordAgeInDays))
-                .build());
-    }
 
     public void saveNewUser(UserEntity newUserEntity) {
         userRepository.save(newUserEntity);
@@ -96,11 +77,7 @@ public class UserDao {
         userRepository.save(user);
     }
 
-    public void editUser(UserDto userDto) {
-        var user = findById(userDto.getId());
-        user.setFirstName(userDto.getFirstName());
-        user.setLastName(userDto.getLastName());
-        user.setEmail(userDto.getEmail());
+    public void editUser(UserEntity user) {
         userRepository.save(user);
     }
 
@@ -130,6 +107,10 @@ public class UserDao {
         return userRepository.findAllById(userIds);
     }
 
+    public void save(UserEntity user) {
+        userRepository.save(user);
+    }
+
     public void save(List<UserEntity> users) {
         userRepository.saveAll(users);
     }
@@ -153,5 +134,11 @@ public class UserDao {
 
     public Optional<UserEntity> findByEmail(String email) {
         return userRepository.findByEmail(email);
+    }
+
+    public UserEntity findByVerificationToken(String token) {
+        return userRepository
+                .findByVerificationToken(token)
+                .orElseThrow(() -> new InvalidVerificationTokenException("Invalid verification token"));
     }
 }

--- a/src/main/java/fi/asteriski/nakitin/dao/VerificationTokenDao.java
+++ b/src/main/java/fi/asteriski/nakitin/dao/VerificationTokenDao.java
@@ -1,0 +1,40 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.dao;
+
+import fi.asteriski.nakitin.entity.UserEntity;
+import fi.asteriski.nakitin.entity.VerificationTokenEntity;
+import fi.asteriski.nakitin.repo.VerificationTokenRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class VerificationTokenDao {
+    private final VerificationTokenRepository verificationTokenRepository;
+
+    public void deleteByUser(UserEntity user) {
+        verificationTokenRepository.deleteByUser(user);
+    }
+
+    public void save(VerificationTokenEntity verificationToken) {
+        verificationTokenRepository.save(verificationToken);
+    }
+
+    public Optional<VerificationTokenEntity> findByToken(String token) {
+        return verificationTokenRepository.findByToken(token);
+    }
+
+    public List<VerificationTokenEntity> findUnverifiedUsersWithExpiredTokens() {
+        return verificationTokenRepository.findAllByExpiryDateIsBefore(LocalDateTime.now());
+    }
+
+    public void deleteByUsers(List<UserEntity> users) {
+        verificationTokenRepository.deleteAllByUserIn(users);
+    }
+}

--- a/src/main/java/fi/asteriski/nakitin/dto/VerificationResult.java
+++ b/src/main/java/fi/asteriski/nakitin/dto/VerificationResult.java
@@ -1,0 +1,10 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.dto;
+
+import lombok.Builder;
+
+@Builder
+public record VerificationResult(boolean verified, String email) {}

--- a/src/main/java/fi/asteriski/nakitin/dto/VerificationStatus.java
+++ b/src/main/java/fi/asteriski/nakitin/dto/VerificationStatus.java
@@ -4,7 +4,8 @@ Licenced under EUPL-1.2 or later.
  */
 package fi.asteriski.nakitin.dto;
 
-import lombok.Builder;
-
-@Builder
-public record VerificationResult(boolean verified, String email, VerificationStatus status) {}
+public enum VerificationStatus {
+    VERIFIED,
+    EXPIRED,
+    NOT_FOUND
+}

--- a/src/main/java/fi/asteriski/nakitin/entity/PasswordResetToken.java
+++ b/src/main/java/fi/asteriski/nakitin/entity/PasswordResetToken.java
@@ -22,9 +22,10 @@ public class PasswordResetToken {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    @Column(nullable = false, unique = true)
     private String token;
 
-    @OneToOne(targetEntity = UserEntity.class, fetch = FetchType.EAGER)
+    @OneToOne(targetEntity = UserEntity.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 

--- a/src/main/java/fi/asteriski/nakitin/entity/PendingEmailChangeEntity.java
+++ b/src/main/java/fi/asteriski/nakitin/entity/PendingEmailChangeEntity.java
@@ -1,0 +1,35 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.entity;
+
+import jakarta.persistence.*;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "pending_email_changes")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PendingEmailChangeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String newEmail;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "verification_token_id")
+    private VerificationTokenEntity verificationToken;
+}

--- a/src/main/java/fi/asteriski/nakitin/entity/UserEntity.java
+++ b/src/main/java/fi/asteriski/nakitin/entity/UserEntity.java
@@ -120,12 +120,31 @@ public class UserEntity implements UserDetails {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private VerificationTokenEntity verificationToken;
 
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private PendingEmailChangeEntity pendingEmailChange;
+
+    public void setPendingEmailChange(String newEmail, VerificationTokenEntity token) {
+        this.pendingEmailChange = PendingEmailChangeEntity.builder()
+                .newEmail(newEmail)
+                .user(this)
+                .verificationToken(token)
+                .build();
+    }
+
+    public void clearPendingEmailChange() {
+        this.pendingEmailChange = null;
+    }
+
     public boolean isOrganisationAdmin() {
         return userRole == ROLE_ORG_ADMIN;
     }
 
     public boolean isAdmin() {
         return userRole == ROLE_ADMIN;
+    }
+
+    public boolean isNotAdmin() {
+        return !isAdmin();
     }
 
     @Override

--- a/src/main/java/fi/asteriski/nakitin/entity/UserEntity.java
+++ b/src/main/java/fi/asteriski/nakitin/entity/UserEntity.java
@@ -10,7 +10,6 @@ import fi.asteriski.nakitin.dto.UserDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -118,11 +117,8 @@ public class UserEntity implements UserDetails {
     @Builder.Default
     private Boolean emailVerified = false;
 
-    @Column(length = 64)
-    private String verificationToken;
-
-    @Column
-    private LocalDateTime verificationTokenExpiry;
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private VerificationTokenEntity verificationToken;
 
     public boolean isOrganisationAdmin() {
         return userRole == ROLE_ORG_ADMIN;

--- a/src/main/java/fi/asteriski/nakitin/entity/UserEntity.java
+++ b/src/main/java/fi/asteriski/nakitin/entity/UserEntity.java
@@ -10,6 +10,7 @@ import fi.asteriski.nakitin.dto.UserDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -113,6 +114,16 @@ public class UserEntity implements UserDetails {
     @Column(nullable = false)
     private Boolean enabled = true;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean emailVerified = false;
+
+    @Column(length = 64)
+    private String verificationToken;
+
+    @Column
+    private LocalDateTime verificationTokenExpiry;
+
     public boolean isOrganisationAdmin() {
         return userRole == ROLE_ORG_ADMIN;
     }
@@ -190,5 +201,9 @@ public class UserEntity implements UserDetails {
 
     public void removeOrganizationAdminRights() {
         setUserRole(ROLE_USER);
+    }
+
+    public boolean isEmailVerified() {
+        return emailVerified;
     }
 }

--- a/src/main/java/fi/asteriski/nakitin/entity/VerificationTokenEntity.java
+++ b/src/main/java/fi/asteriski/nakitin/entity/VerificationTokenEntity.java
@@ -1,0 +1,48 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "verification_tokens")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VerificationTokenEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, length = 64, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    public void addUser(UserEntity user) {
+        this.user = user;
+        user.setVerificationToken(this);
+    }
+
+    public void removeUser(UserEntity user) {
+        if (Objects.equals(this.user, user)) {
+            this.user.setVerificationToken(null);
+            this.user = null;
+        }
+    }
+}

--- a/src/main/java/fi/asteriski/nakitin/exceptions/InvalidVerificationTokenException.java
+++ b/src/main/java/fi/asteriski/nakitin/exceptions/InvalidVerificationTokenException.java
@@ -1,0 +1,11 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.exceptions;
+
+public class InvalidVerificationTokenException extends RuntimeException {
+    public InvalidVerificationTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fi/asteriski/nakitin/repo/PasswordResetTokenRepository.java
+++ b/src/main/java/fi/asteriski/nakitin/repo/PasswordResetTokenRepository.java
@@ -5,6 +5,8 @@ Licenced under EUPL-1.2 or later.
 package fi.asteriski.nakitin.repo;
 
 import fi.asteriski.nakitin.entity.PasswordResetToken;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +15,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, UUID> {
     Optional<PasswordResetToken> findByToken(String token);
+
+    List<PasswordResetToken> findAllByExpiryDateIsBefore(LocalDateTime expiryDateBefore);
 }

--- a/src/main/java/fi/asteriski/nakitin/repo/UserRepository.java
+++ b/src/main/java/fi/asteriski/nakitin/repo/UserRepository.java
@@ -47,4 +47,6 @@ public interface UserRepository extends JpaRepository<UserEntity, UUID> {
         delete from users where id in :toDelete
         """)
     void deleteUsersById(@Param("toDelete") List<UUID> toDelete);
+
+    Optional<UserEntity> findByVerificationToken_Token(String verificationTokenToken);
 }

--- a/src/main/java/fi/asteriski/nakitin/repo/UserRepository.java
+++ b/src/main/java/fi/asteriski/nakitin/repo/UserRepository.java
@@ -40,4 +40,6 @@ public interface UserRepository extends JpaRepository<UserEntity, UUID> {
     Optional<UserDetailsProjection> findUserEntityById(UUID id);
 
     Optional<UserEntity> findByEmail(String email);
+
+    Optional<UserEntity> findByVerificationToken(String verificationToken);
 }

--- a/src/main/java/fi/asteriski/nakitin/repo/UserRepository.java
+++ b/src/main/java/fi/asteriski/nakitin/repo/UserRepository.java
@@ -7,10 +7,13 @@ package fi.asteriski.nakitin.repo;
 import fi.asteriski.nakitin.entity.UserEntity;
 import fi.asteriski.nakitin.entity.UserRole;
 import fi.asteriski.nakitin.repo.projection.IdFirstLastNameProjection;
+import fi.asteriski.nakitin.repo.projection.IdProjection;
 import fi.asteriski.nakitin.repo.projection.UserDetailsProjection;
+import java.time.LocalDateTime;
 import java.util.*;
 import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.NativeQuery;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -42,4 +45,13 @@ public interface UserRepository extends JpaRepository<UserEntity, UUID> {
     Optional<UserEntity> findByEmail(String email);
 
     Optional<UserEntity> findByVerificationToken(String verificationToken);
+
+    List<IdProjection> findAllByVerificationTokenExpiryBeforeAndEmailVerifiedIsFalse(
+            LocalDateTime verificationTokenExpiryBefore);
+
+    @Modifying
+    @NativeQuery("""
+        delete from users where id in :toDelete
+        """)
+    void deleteUsersById(@Param("toDelete") List<UUID> toDelete);
 }

--- a/src/main/java/fi/asteriski/nakitin/repo/UserRepository.java
+++ b/src/main/java/fi/asteriski/nakitin/repo/UserRepository.java
@@ -7,9 +7,7 @@ package fi.asteriski.nakitin.repo;
 import fi.asteriski.nakitin.entity.UserEntity;
 import fi.asteriski.nakitin.entity.UserRole;
 import fi.asteriski.nakitin.repo.projection.IdFirstLastNameProjection;
-import fi.asteriski.nakitin.repo.projection.IdProjection;
 import fi.asteriski.nakitin.repo.projection.UserDetailsProjection;
-import java.time.LocalDateTime;
 import java.util.*;
 import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -43,11 +41,6 @@ public interface UserRepository extends JpaRepository<UserEntity, UUID> {
     Optional<UserDetailsProjection> findUserEntityById(UUID id);
 
     Optional<UserEntity> findByEmail(String email);
-
-    Optional<UserEntity> findByVerificationToken(String verificationToken);
-
-    List<IdProjection> findAllByVerificationTokenExpiryBeforeAndEmailVerifiedIsFalse(
-            LocalDateTime verificationTokenExpiryBefore);
 
     @Modifying
     @NativeQuery("""

--- a/src/main/java/fi/asteriski/nakitin/repo/VerificationTokenRepository.java
+++ b/src/main/java/fi/asteriski/nakitin/repo/VerificationTokenRepository.java
@@ -1,0 +1,26 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.repo;
+
+import fi.asteriski.nakitin.entity.UserEntity;
+import fi.asteriski.nakitin.entity.VerificationTokenEntity;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VerificationTokenRepository extends JpaRepository<VerificationTokenEntity, UUID> {
+    Optional<VerificationTokenEntity> findByToken(String token);
+
+    void deleteByUser(UserEntity user);
+
+    List<VerificationTokenEntity> findAllByExpiryDateIsBefore(LocalDateTime expiryDateBefore);
+
+    void deleteAllByUserIn(Collection<UserEntity> users);
+}

--- a/src/main/java/fi/asteriski/nakitin/repo/projection/IdProjection.java
+++ b/src/main/java/fi/asteriski/nakitin/repo/projection/IdProjection.java
@@ -1,0 +1,11 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.repo.projection;
+
+import java.util.UUID;
+
+public interface IdProjection {
+    UUID getId();
+}

--- a/src/main/java/fi/asteriski/nakitin/service/EmailService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/EmailService.java
@@ -70,6 +70,19 @@ public class EmailService {
         }
     }
 
+    public void sendEmailChangeVerification(String toEmail, String verificationUrl) {
+        var subject = messageSource.getMessage("email.subject.verification", null, LocaleContextHolder.getLocale());
+        var message = messageSource.getMessage(
+                "email.message.email-change-verification",
+                new Object[] {verificationUrl},
+                LocaleContextHolder.getLocale());
+        try {
+            sendEmail(toEmail, defaultSender, subject, message);
+        } catch (MessagingException e) {
+            log.error(LOG_ERROR_MESSAGE_TEMPLATE.formatted(e));
+        }
+    }
+
     private void sendEmail(String recipient, String sender, String messageSubject, String messageText)
             throws MessagingException {
         var msg = mailSender.createMimeMessage();

--- a/src/main/java/fi/asteriski/nakitin/service/EmailService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/EmailService.java
@@ -48,9 +48,7 @@ public class EmailService {
     public void sendEmailVerification(String toEmail, String verificationUrl) {
         var subject = messageSource.getMessage("email.subject.verification", null, LocaleContextHolder.getLocale());
         var message = messageSource.getMessage(
-                "email.message.verification",
-                new Object[] {verificationUrl, verificationUrl},
-                LocaleContextHolder.getLocale());
+                "email.message.verification", new Object[] {verificationUrl}, LocaleContextHolder.getLocale());
         try {
             sendEmail(toEmail, defaultSender, subject, message);
         } catch (MessagingException e) {

--- a/src/main/java/fi/asteriski/nakitin/service/EmailService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/EmailService.java
@@ -48,7 +48,9 @@ public class EmailService {
     public void sendEmailVerification(String toEmail, String verificationUrl) {
         var subject = messageSource.getMessage("email.subject.verification", null, LocaleContextHolder.getLocale());
         var message = messageSource.getMessage(
-                "email.message.verification", new Object[] {verificationUrl}, LocaleContextHolder.getLocale());
+                "email.message.verification",
+                new Object[] {verificationUrl, verificationUrl},
+                LocaleContextHolder.getLocale());
         try {
             sendEmail(toEmail, defaultSender, subject, message);
         } catch (MessagingException e) {

--- a/src/main/java/fi/asteriski/nakitin/service/ScheduledTasksService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/ScheduledTasksService.java
@@ -4,6 +4,7 @@ Licenced under EUPL-1.2 or later.
  */
 package fi.asteriski.nakitin.service;
 
+import fi.asteriski.nakitin.dao.PasswordResetTokenDao;
 import fi.asteriski.nakitin.dao.UserDao;
 import fi.asteriski.nakitin.dao.VerificationTokenDao;
 import fi.asteriski.nakitin.entity.UserEntity;
@@ -21,8 +22,9 @@ public class ScheduledTasksService {
 
     private final VerificationTokenDao verificationTokenDao;
     private final UserDao userDao;
+    private final PasswordResetTokenDao passwordResetTokenDao;
 
-    @Scheduled(cron = "${fi.asteriski.config.cleanup.unverified-users-cron}")
+    @Scheduled(cron = "${fi.asteriski.config.cleanup.unverifiedUsersCron}")
     @Transactional
     public void cleanupUnverifiedUsers() {
         log.info("Starting cleanup of unverified users with expired tokens.");
@@ -32,7 +34,21 @@ public class ScheduledTasksService {
             var users = toDelete.stream().map(VerificationTokenEntity::getUser).toList();
             toDelete.forEach(token -> token.removeUser(token.getUser()));
             verificationTokenDao.deleteByUsers(users);
-            userDao.deleteUsersById(users.stream().map(UserEntity::getId).toList());
+            userDao.deleteUsersById(users.stream()
+                    .filter(UserEntity::isNotAdmin)
+                    .map(UserEntity::getId)
+                    .toList());
+        }
+    }
+
+    @Scheduled(cron = "${fi.asteriski.config.cleanup.passwordResetCron}")
+    @Transactional
+    public void cleanupPasswordResetTokens() {
+        log.info("Starting cleanup of expired password reset tokens.");
+        var toDelete = passwordResetTokenDao.findExpiredTokens();
+        if (!toDelete.isEmpty()) {
+            log.info("Deleting {} expired tokens.", toDelete.size());
+            passwordResetTokenDao.deleteAll(toDelete);
         }
     }
 }

--- a/src/main/java/fi/asteriski/nakitin/service/ScheduledTasksService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/ScheduledTasksService.java
@@ -5,6 +5,9 @@ Licenced under EUPL-1.2 or later.
 package fi.asteriski.nakitin.service;
 
 import fi.asteriski.nakitin.dao.UserDao;
+import fi.asteriski.nakitin.dao.VerificationTokenDao;
+import fi.asteriski.nakitin.entity.UserEntity;
+import fi.asteriski.nakitin.entity.VerificationTokenEntity;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -16,16 +19,20 @@ import org.springframework.transaction.annotation.Transactional;
 @AllArgsConstructor
 public class ScheduledTasksService {
 
+    private final VerificationTokenDao verificationTokenDao;
     private final UserDao userDao;
 
     @Scheduled(cron = "${fi.asteriski.config.cleanup.unverified-users-cron}")
     @Transactional
     public void cleanupUnverifiedUsers() {
         log.info("Starting cleanup of unverified users with expired tokens.");
-        var toDelete = userDao.findUnverifiedUsersWithExpiredTokens();
+        var toDelete = verificationTokenDao.findUnverifiedUsersWithExpiredTokens();
         if (!toDelete.isEmpty()) {
             log.info("Deleting {} unverified users with expired tokens.", toDelete.size());
-            userDao.deleteUsersById(toDelete);
+            var users = toDelete.stream().map(VerificationTokenEntity::getUser).toList();
+            toDelete.forEach(token -> token.removeUser(token.getUser()));
+            verificationTokenDao.deleteByUsers(users);
+            userDao.deleteUsersById(users.stream().map(UserEntity::getId).toList());
         }
     }
 }

--- a/src/main/java/fi/asteriski/nakitin/service/ScheduledTasksService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/ScheduledTasksService.java
@@ -1,0 +1,31 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.service;
+
+import fi.asteriski.nakitin.dao.UserDao;
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Log4j2
+@AllArgsConstructor
+public class ScheduledTasksService {
+
+    private final UserDao userDao;
+
+    @Scheduled(cron = "${fi.asteriski.config.cleanup.unverified-users-cron}")
+    @Transactional
+    public void cleanupUnverifiedUsers() {
+        log.info("Starting cleanup of unverified users with expired tokens.");
+        var toDelete = userDao.findUnverifiedUsersWithExpiredTokens();
+        if (!toDelete.isEmpty()) {
+            log.info("Deleting {} unverified users with expired tokens.", toDelete.size());
+            userDao.deleteUsersById(toDelete);
+        }
+    }
+}

--- a/src/main/java/fi/asteriski/nakitin/service/UserService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/UserService.java
@@ -4,14 +4,12 @@ Licenced under EUPL-1.2 or later.
  */
 package fi.asteriski.nakitin.service;
 
+import static fi.asteriski.nakitin.dto.VerificationStatus.*;
 import static fi.asteriski.nakitin.entity.UserRole.*;
 
 import fi.asteriski.nakitin.dao.PasswordResetTokenDao;
 import fi.asteriski.nakitin.dao.UserDao;
-import fi.asteriski.nakitin.dto.IdFirstLastNameDto;
-import fi.asteriski.nakitin.dto.SignupForm;
-import fi.asteriski.nakitin.dto.UserDto;
-import fi.asteriski.nakitin.dto.VerificationResult;
+import fi.asteriski.nakitin.dto.*;
 import fi.asteriski.nakitin.dto.admin.AddUserForm;
 import fi.asteriski.nakitin.dto.admin.UserInfoForm;
 import fi.asteriski.nakitin.entity.OrganizationEntity;
@@ -130,21 +128,9 @@ public class UserService implements UserDetailsService {
 
     @Transactional
     public VerificationResult verifyEmail(String token) {
-        UserEntity user = userDao.findByVerificationToken(token);
-
-        if (verificationTokenService.isTokenExpired(user.getVerificationTokenExpiry())) {
-            return VerificationResult.builder()
-                    .verified(false)
-                    .email(user.getEmail())
-                    .build();
-        }
-
-        user.setEmailVerified(true);
-        user.setVerificationToken(null);
-        user.setVerificationTokenExpiry(null);
-        userDao.save(user);
-
-        return VerificationResult.builder().verified(true).email(null).build();
+        return userDao.findByVerificationToken(token)
+                .map(this::processUserVerification)
+                .orElse(createVerificationResult(false, null, NOT_FOUND));
     }
 
     public Page<UserEntity> fetchAllUsersForAdmin(int page) {
@@ -261,18 +247,42 @@ public class UserService implements UserDetailsService {
         return true;
     }
 
-    private String getBaseUrl(HttpServletRequest request) {
-        String scheme = request.getScheme();
-        String serverName = request.getServerName();
-        return "%s://%s:%s%s".formatted(scheme, serverName, serverPort, contextPath);
-    }
-
     public void setupEmailVerification(UserEntity user, HttpServletRequest request) {
-        String token = verificationTokenService.generateVerificationToken();
+        var token = verificationTokenService.generateVerificationToken();
         user.setVerificationToken(token);
         user.setVerificationTokenExpiry(verificationTokenService.calculateExpiryDate());
 
-        String verificationUrl = "%s/verify-email?token=%s".formatted(getBaseUrl(request), token);
+        var verificationUrl = "%s/verify-email?token=%s".formatted(getBaseUrl(request), token);
         emailService.sendEmailVerification(user.getEmail(), verificationUrl);
+    }
+
+    private String getBaseUrl(HttpServletRequest request) {
+        var scheme = request.getScheme();
+        var serverName = request.getServerName();
+        return "%s://%s:%s%s".formatted(scheme, serverName, serverPort, contextPath);
+    }
+
+    private VerificationResult processUserVerification(UserEntity user) {
+        if (verificationTokenService.isTokenExpired(user.getVerificationTokenExpiry())) {
+            return createVerificationResult(false, user.getEmail(), EXPIRED);
+        }
+
+        verifyUserEmail(user);
+        return createVerificationResult(true, null, VERIFIED);
+    }
+
+    private void verifyUserEmail(UserEntity user) {
+        user.setEmailVerified(true);
+        user.setVerificationToken(null);
+        user.setVerificationTokenExpiry(null);
+        userDao.save(user);
+    }
+
+    private VerificationResult createVerificationResult(boolean verified, String email, VerificationStatus status) {
+        return VerificationResult.builder()
+                .verified(verified)
+                .email(email)
+                .status(status)
+                .build();
     }
 }

--- a/src/main/java/fi/asteriski/nakitin/service/UserService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/UserService.java
@@ -11,11 +11,14 @@ import fi.asteriski.nakitin.dao.UserDao;
 import fi.asteriski.nakitin.dto.IdFirstLastNameDto;
 import fi.asteriski.nakitin.dto.SignupForm;
 import fi.asteriski.nakitin.dto.UserDto;
+import fi.asteriski.nakitin.dto.VerificationResult;
 import fi.asteriski.nakitin.dto.admin.AddUserForm;
 import fi.asteriski.nakitin.dto.admin.UserInfoForm;
 import fi.asteriski.nakitin.entity.OrganizationEntity;
 import fi.asteriski.nakitin.entity.PasswordResetToken;
 import fi.asteriski.nakitin.entity.UserEntity;
+import fi.asteriski.nakitin.entity.UserRole;
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -49,11 +52,23 @@ public class UserService implements UserDetailsService {
     @NonNull
     private final PasswordResetTokenDao passwordResetTokenDao;
 
+    @NonNull
+    private final VerificationTokenService verificationTokenService;
+
+    @NonNull
+    private final EmailService emailService;
+
     @Value("${fi.asteriski.config.maxPasswordAgeInDays}")
     private Long maxPasswordAgeInDays;
 
     @Value("${fi.asteriski.config.passwordResetTokenExpirationHours}")
     private Integer passwordResetTokenExpirationHours;
+
+    @Value("${server.servlet.context-path:}")
+    private String contextPath;
+
+    @Value("${server.port:8080}")
+    private String serverPort;
 
     /**
      * Fetches a user from database on login. Called automatically by Spring.
@@ -72,14 +87,18 @@ public class UserService implements UserDetailsService {
     }
 
     @Transactional
-    public void createNewUser(SignupForm signupForm) {
-        userDao.saveNewUser(UserDto.builder()
+    public void createNewUser(SignupForm signupForm, HttpServletRequest request) {
+        var user = UserEntity.builder()
                 .username(signupForm.getUsername())
                 .password(passwordEncoder.encode(signupForm.getPassword()))
                 .email(signupForm.getEmail())
                 .firstName(signupForm.getFirstName())
                 .lastName(signupForm.getLastName())
-                .build());
+                .expirationDate(LocalDate.now().plusDays(maxPasswordAgeInDays))
+                .userRole(UserRole.ROLE_USER)
+                .build();
+        setupEmailVerification(user, request);
+        userDao.saveNewUser(user);
     }
 
     public boolean existsByEmail(String email) {
@@ -99,8 +118,33 @@ public class UserService implements UserDetailsService {
     }
 
     @Transactional
-    public void updateUser(UserDto userDto) {
-        userDao.editUser(userDto);
+    public void updateUser(UserDto userDto, HttpServletRequest request) {
+        var user = userDao.findById(userDto.getId());
+        user.setFirstName(userDto.getFirstName());
+        user.setLastName(userDto.getLastName());
+        user.setEmail(userDto.getEmail());
+        user.setEmailVerified(false);
+        setupEmailVerification(user, request);
+        userDao.editUser(user);
+    }
+
+    @Transactional
+    public VerificationResult verifyEmail(String token) {
+        UserEntity user = userDao.findByVerificationToken(token);
+
+        if (verificationTokenService.isTokenExpired(user.getVerificationTokenExpiry())) {
+            return VerificationResult.builder()
+                    .verified(false)
+                    .email(user.getEmail())
+                    .build();
+        }
+
+        user.setEmailVerified(true);
+        user.setVerificationToken(null);
+        user.setVerificationTokenExpiry(null);
+        userDao.save(user);
+
+        return VerificationResult.builder().verified(true).email(null).build();
     }
 
     public Page<UserEntity> fetchAllUsersForAdmin(int page) {
@@ -215,5 +259,20 @@ public class UserService implements UserDetailsService {
         passwordResetTokenDao.delete(passwordResetToken);
 
         return true;
+    }
+
+    private String getBaseUrl(HttpServletRequest request) {
+        String scheme = request.getScheme();
+        String serverName = request.getServerName();
+        return "%s://%s:%s%s".formatted(scheme, serverName, serverPort, contextPath);
+    }
+
+    public void setupEmailVerification(UserEntity user, HttpServletRequest request) {
+        String token = verificationTokenService.generateVerificationToken();
+        user.setVerificationToken(token);
+        user.setVerificationTokenExpiry(verificationTokenService.calculateExpiryDate());
+
+        String verificationUrl = "%s/verify-email?token=%s".formatted(getBaseUrl(request), token);
+        emailService.sendEmailVerification(user.getEmail(), verificationUrl);
     }
 }

--- a/src/main/java/fi/asteriski/nakitin/service/UserService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/UserService.java
@@ -17,10 +17,7 @@ import fi.asteriski.nakitin.entity.*;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -117,22 +114,70 @@ public class UserService implements UserDetailsService {
     }
 
     @Transactional
-    public void updateUser(UserDto userDto, HttpServletRequest request) {
+    public boolean updateUser(UserDto userDto, HttpServletRequest request) {
         var user = userDao.findById(userDto.getId());
         user.setFirstName(userDto.getFirstName());
         user.setLastName(userDto.getLastName());
-        user.setEmail(userDto.getEmail());
-        user.setEmailVerified(false);
-        setupEmailVerification(user, request);
-        userDao.editUser(user);
+
+        boolean emailChanged = !user.getEmail().equals(userDto.getEmail());
+        if (emailChanged) {
+            setupEmailChangeVerification(user, userDto.getEmail(), request);
+        }
+
+        userDao.save(user);
+        return emailChanged;
+    }
+
+    private void setupEmailChangeVerification(UserEntity user, String newEmail, HttpServletRequest request) {
+        var token = verificationTokenService.generateVerificationToken();
+        var verificationToken = VerificationTokenEntity.builder()
+                .token(token)
+                .expiryDate(verificationTokenService.calculateExpiryDate())
+                .build();
+
+        user.setPendingEmailChange(newEmail, verificationToken);
+        verificationToken.addUser(user);
+
+        var verificationUrl = "%s/verify-email?token=%s".formatted(getBaseUrl(request), token);
+        emailService.sendEmailChangeVerification(newEmail, verificationUrl);
     }
 
     @Transactional
     public VerificationResult verifyEmail(String token) {
-        return verificationTokenDao
-                .findByToken(token)
-                .map(this::processUserVerification)
+        return userDao.findByVerificationToken(token)
+                .map(user -> {
+                    if (user.getPendingEmailChange() != null) {
+                        return processEmailChangeVerification(user);
+                    }
+                    return processNewUserVerification(user);
+                })
                 .orElse(createVerificationResult(false, null, NOT_FOUND));
+    }
+
+    private VerificationResult processEmailChangeVerification(UserEntity user) {
+        var newEmail = user.getPendingEmailChange().getNewEmail();
+        if (verificationTokenService.isTokenExpired(
+                user.getPendingEmailChange().getVerificationToken().getExpiryDate())) {
+            return createVerificationResult(false, newEmail, EXPIRED);
+        }
+
+        user.getPendingEmailChange().getVerificationToken().removeUser(user);
+
+        user.setEmail(newEmail);
+        user.setEmailVerified(true);
+        user.clearPendingEmailChange();
+        userDao.save(user);
+
+        return createVerificationResult(true, null, VERIFIED);
+    }
+
+    private VerificationResult processNewUserVerification(UserEntity user) {
+        if (verificationTokenService.isTokenExpired(user.getVerificationToken().getExpiryDate())) {
+            return createVerificationResult(false, user.getEmail(), EXPIRED);
+        }
+
+        verifyUserEmail(user);
+        return createVerificationResult(true, null, VERIFIED);
     }
 
     public Page<UserEntity> fetchAllUsersForAdmin(int page) {
@@ -270,19 +315,10 @@ public class UserService implements UserDetailsService {
         return "%s://%s:%s%s".formatted(scheme, serverName, serverPort, contextPath);
     }
 
-    private VerificationResult processUserVerification(VerificationTokenEntity token) {
-        if (verificationTokenService.isTokenExpired(token.getExpiryDate())) {
-            return createVerificationResult(false, token.getUser().getEmail(), EXPIRED);
-        }
-
-        verifyUserEmail(token);
-        return createVerificationResult(true, null, VERIFIED);
-    }
-
-    private void verifyUserEmail(VerificationTokenEntity token) {
-        token.getUser().setEmailVerified(true);
-        token.removeUser(token.getUser());
-        verificationTokenDao.deleteByUser(token.getUser());
+    private void verifyUserEmail(UserEntity user) {
+        user.setEmailVerified(true);
+        user.getVerificationToken().removeUser(user);
+        verificationTokenDao.deleteByUser(user);
     }
 
     private VerificationResult createVerificationResult(boolean verified, String email, VerificationStatus status) {

--- a/src/main/java/fi/asteriski/nakitin/service/UserService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/UserService.java
@@ -9,13 +9,11 @@ import static fi.asteriski.nakitin.entity.UserRole.*;
 
 import fi.asteriski.nakitin.dao.PasswordResetTokenDao;
 import fi.asteriski.nakitin.dao.UserDao;
+import fi.asteriski.nakitin.dao.VerificationTokenDao;
 import fi.asteriski.nakitin.dto.*;
 import fi.asteriski.nakitin.dto.admin.AddUserForm;
 import fi.asteriski.nakitin.dto.admin.UserInfoForm;
-import fi.asteriski.nakitin.entity.OrganizationEntity;
-import fi.asteriski.nakitin.entity.PasswordResetToken;
-import fi.asteriski.nakitin.entity.UserEntity;
-import fi.asteriski.nakitin.entity.UserRole;
+import fi.asteriski.nakitin.entity.*;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -38,6 +36,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService implements UserDetailsService {
+    @NonNull
+    private final VerificationTokenDao verificationTokenDao;
+
     @NonNull
     private final BCryptPasswordEncoder passwordEncoder;
 
@@ -128,7 +129,8 @@ public class UserService implements UserDetailsService {
 
     @Transactional
     public VerificationResult verifyEmail(String token) {
-        return userDao.findByVerificationToken(token)
+        return verificationTokenDao
+                .findByToken(token)
                 .map(this::processUserVerification)
                 .orElse(createVerificationResult(false, null, NOT_FOUND));
     }
@@ -247,10 +249,16 @@ public class UserService implements UserDetailsService {
         return true;
     }
 
+    @Transactional
     public void setupEmailVerification(UserEntity user, HttpServletRequest request) {
         var token = verificationTokenService.generateVerificationToken();
-        user.setVerificationToken(token);
-        user.setVerificationTokenExpiry(verificationTokenService.calculateExpiryDate());
+        var verificationToken = VerificationTokenEntity.builder()
+                .token(token)
+                .expiryDate(verificationTokenService.calculateExpiryDate())
+                .build();
+
+        verificationToken.addUser(user);
+        userDao.save(user);
 
         var verificationUrl = "%s/verify-email?token=%s".formatted(getBaseUrl(request), token);
         emailService.sendEmailVerification(user.getEmail(), verificationUrl);
@@ -262,20 +270,19 @@ public class UserService implements UserDetailsService {
         return "%s://%s:%s%s".formatted(scheme, serverName, serverPort, contextPath);
     }
 
-    private VerificationResult processUserVerification(UserEntity user) {
-        if (verificationTokenService.isTokenExpired(user.getVerificationTokenExpiry())) {
-            return createVerificationResult(false, user.getEmail(), EXPIRED);
+    private VerificationResult processUserVerification(VerificationTokenEntity token) {
+        if (verificationTokenService.isTokenExpired(token.getExpiryDate())) {
+            return createVerificationResult(false, token.getUser().getEmail(), EXPIRED);
         }
 
-        verifyUserEmail(user);
+        verifyUserEmail(token);
         return createVerificationResult(true, null, VERIFIED);
     }
 
-    private void verifyUserEmail(UserEntity user) {
-        user.setEmailVerified(true);
-        user.setVerificationToken(null);
-        user.setVerificationTokenExpiry(null);
-        userDao.save(user);
+    private void verifyUserEmail(VerificationTokenEntity token) {
+        token.getUser().setEmailVerified(true);
+        token.removeUser(token.getUser());
+        verificationTokenDao.deleteByUser(token.getUser());
     }
 
     private VerificationResult createVerificationResult(boolean verified, String email, VerificationStatus status) {

--- a/src/main/java/fi/asteriski/nakitin/service/VerificationTokenService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/VerificationTokenService.java
@@ -1,0 +1,28 @@
+/*
+Copyright Juhani Vähä-Mäkilä (juhani@fmail.co.uk) 2025.
+Licenced under EUPL-1.2 or later.
+ */
+package fi.asteriski.nakitin.service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+@Service
+@Log4j2
+public class VerificationTokenService {
+    private static final int TOKEN_EXPIRY_HOURS = 24;
+
+    public String generateVerificationToken() {
+        return UUID.randomUUID().toString();
+    }
+
+    public LocalDateTime calculateExpiryDate() {
+        return LocalDateTime.now().plusHours(TOKEN_EXPIRY_HOURS);
+    }
+
+    public boolean isTokenExpired(LocalDateTime expiryDate) {
+        return expiryDate != null && LocalDateTime.now().isAfter(expiryDate);
+    }
+}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -26,6 +26,7 @@ spring.mail.properties.mail.smtp.writetimeout=5000
 
 # Custom configs
 fi.asteriski.config.maxPasswordAgeInDays=${PASSWORD_MAX_AGE}
+fi.asteriski.config.passwordResetTokenExpirationHours=${PASSWORD_RESET_TOKEN_EXPIRATION:24}
 
 # Rate limiting configuration
 ratelimit.login.maxAttempts=${RATE_LIMIT_MAX_LOGIN_ATTEMPTS:5}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -27,7 +27,8 @@ spring.mail.properties.mail.smtp.writetimeout=5000
 # Custom configs
 fi.asteriski.config.maxPasswordAgeInDays=${PASSWORD_MAX_AGE}
 fi.asteriski.config.passwordResetTokenExpirationHours=${PASSWORD_RESET_TOKEN_EXPIRATION:24}
-fi.asteriski.config.cleanup.unverified-users-cron=@daily
+fi.asteriski.config.cleanup.unverifiedUsersCron=@daily
+fi.asteriski.config.cleanup.passwordResetCron=@daily
 
 # Rate limiting configuration
 ratelimit.login.maxAttempts=${RATE_LIMIT_MAX_LOGIN_ATTEMPTS:5}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -27,6 +27,7 @@ spring.mail.properties.mail.smtp.writetimeout=5000
 # Custom configs
 fi.asteriski.config.maxPasswordAgeInDays=${PASSWORD_MAX_AGE}
 fi.asteriski.config.passwordResetTokenExpirationHours=${PASSWORD_RESET_TOKEN_EXPIRATION:24}
+fi.asteriski.config.cleanup.unverified-users-cron=@daily
 
 # Rate limiting configuration
 ratelimit.login.maxAttempts=${RATE_LIMIT_MAX_LOGIN_ATTEMPTS:5}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,7 @@ spring.mvc.format.time=iso
 # Custom configs
 fi.asteriski.config.maxPasswordAgeInDays=365
 fi.asteriski.config.email.default-sender-address=noreply@asteriski.fi
+fi.asteriski.config.passwordResetTokenExpirationHours=24
 
 # Rate limiting configuration
 ratelimit.login.maxAttempts=5

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,6 +32,7 @@ spring.mvc.format.time=iso
 fi.asteriski.config.maxPasswordAgeInDays=365
 fi.asteriski.config.email.default-sender-address=noreply@asteriski.fi
 fi.asteriski.config.passwordResetTokenExpirationHours=24
+fi.asteriski.config.cleanup.unverified-users-cron=0 */1 * * * *
 
 # Rate limiting configuration
 ratelimit.login.maxAttempts=5

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,7 +32,8 @@ spring.mvc.format.time=iso
 fi.asteriski.config.maxPasswordAgeInDays=365
 fi.asteriski.config.email.default-sender-address=noreply@asteriski.fi
 fi.asteriski.config.passwordResetTokenExpirationHours=24
-fi.asteriski.config.cleanup.unverified-users-cron=0 */1 * * * *
+fi.asteriski.config.cleanup.unverifiedUsersCron=0 */1 * * * *
+fi.asteriski.config.cleanup.passwordResetCron=0 */1 * * * *
 
 # Rate limiting configuration
 ratelimit.login.maxAttempts=5

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -45,7 +45,7 @@ register.form.label.password=Salasana
 register.form.label.passwordConfirm=Salasana uudestaan
 
 success.register.title=Rekister\u00F6inti onnistui
-success.register.text=Voit nyt kirjautua sis\u00E4\u00E4n ja nakittautua.
+success.register.text=Antamaasi s\u00E4hk\u00F6postiosoitteeseen on l\u00E4hetetty vahvistuslinkki. Tili tulee vahvistaa ennen kuin voit kirjautua sis\u00E4\u00E4n.
 success.deleteEvent.title=Tapahtuman poisto onnistui
 success.deleteEvent.text=Tapahtuma poistettiin onnistuneesti.
 success.deleteTask.title=Poisto onnistui
@@ -253,6 +253,7 @@ auth.login.password=Salasana
 auth.login.remember-me=Muista minut
 auth.login.submit=Kirjaudu
 auth.login.forgot-password=Unohditko salasanasi?
+auth.error.email.not.verified=S\u00E4hk\u00F6postiosoitetta ei ole vahvistettu
 
 email.subject.password-reset=Salasanan nollaus
 email.subject.verification=Vahvista s\u00E4hk\u00F6postiosoitteesi
@@ -279,7 +280,7 @@ email.message.verification=<!DOCTYPE html>\
 <div style="max-width: 600px; margin: 0 auto; padding: 20px;">\
     <p>Hei,</p>\
     <p>Kiitos rekister\u00F6itymisest\u00E4si. Vahvista s\u00E4hk\u00F6postiosoitteesi klikkaamalla alla olevaa linkki\u00E4:</p>\
-    <p><a href="{0}" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">Vahvista s\u00E4hk\u00F6postiosoite</a></p>\
+    <p><a href="{0}" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">{1}/a></p>\
     <p>Linkki on voimassa 24 tuntia.</p>\
     <p>Yst\u00E4v\u00E4llisin terveisin,<br>Nakitin-tiimi</p>\
 </div>\
@@ -296,3 +297,9 @@ email.message.password-expiration=<!DOCTYPE html>\
 </div>\
 </body>\
 </html>
+verification.button.resend=L\u00E4het\u00E4 vahvistusviesti uudestaan
+verification.success.message=S\u00E4hk\u00F6posti vahvistettiin onnistuneesti
+verification.error.expired=Vahvistuslinkki on vanhentunut
+verification.title=S\u00E4hk\u00F6postin vahvistus
+verification.error.unverified=Vahvistamaton s\u00E4hk\u00F6postiosoite
+verification.notification.sent=Vahvistuslinkki on l\u00E4hetetty antamaasi s\u00E4hk\u00F6postiosoitteeseen

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -65,6 +65,9 @@ profile.label.email=S\u00E4hk\u00F6postiosoite:
 profile.label.edit=Muokkaa tietoja
 profile.label.update.success.title=Tietojen p\u00E4ivitys onnistui
 profile.label.update.success.text=Tiedot p\u00E4ivitettiin onnistuneesti.
+# Note: these are in use in the profile.html template.
+profile.label.update.success.updateEmail=Vaihtamasi s\u00E4hk\u00F6postiosoite pit\u00E4\u00E4 verifioida. Antamaasi osoitteeseen on l\u00E4hetetty vahvistusviesti.
+profile.label.update.success.empty=
 
 form.button.label.sign-up=Rekister\u00F6idy
 form.button.label.login=Kirjaudu sis\u00E4\u00E4n
@@ -260,7 +263,7 @@ email.message.password-reset=<!DOCTYPE html>\
 <div style="max-width: 600px; margin: 0 auto; padding: 20px;">\
     <p>Hei,</p>\
     <p>Sinulle on pyydetty salasanan nollausta. Nollataksesi salasanasi, klikkaa alla olevaa linkki\u00E4:</p>\
-    <p><a href="{0}" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">Nollaa salasana</a></p>\
+    <p><a href="{0}" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">{0}</a></p>\
     <p>Jos et pyyt\u00E4nyt salasanan nollausta, voit j\u00E4tt\u00E4\u00E4 t\u00E4m\u00E4n viestin huomiotta.</p>\
     <p>Linkki on voimassa 24 tuntia.</p>\
     <p>Yst\u00E4v\u00E4llisin terveisin,<br>Nakitin-tiimi</p>\
@@ -287,6 +290,18 @@ email.message.password-expiration=<!DOCTYPE html>\
 <div style="max-width: 600px; margin: 0 auto; padding: 20px;">\
     <p>Hei,</p>\
     <p>Salasanasi vanhenee {0} p\u00E4iv\u00E4n kuluttua. Kirjaudu sis\u00E4\u00E4n tilillesi ja vaihda salasanasi.</p>\
+    <p>Yst\u00E4v\u00E4llisin terveisin,<br>Nakitin-tiimi</p>\
+</div>\
+</body>\
+</html>
+email.message.email-change-verification=<!DOCTYPE html>\
+<html>\
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">\
+<div style="max-width: 600px; margin: 0 auto; padding: 20px;">\
+    <p>Hei,</p>\
+    <p>Olet pyyt\u00E4nyt vaihtamaan Nakkittimen s\u00E4hk\u00F6postiosoitettasi. Vaihto ei tule voimaan ennen vahvistusta. Vahvista s\u00E4hk\u00F6postiosoitteesi klikkaamalla alla olevaa linkki\u00E4:</p>\
+    <p><a href="{0}" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">{0}</a></p>\
+    <p>Linkki on voimassa 24 tuntia.</p>\
     <p>Yst\u00E4v\u00E4llisin terveisin,<br>Nakitin-tiimi</p>\
 </div>\
 </body>\

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -214,7 +214,6 @@ deleteTask.text.p3=Itse nakin lis\u00E4ksi poistetaan seuraavat asiat:
 deleteTask.text.volunteers=Kaikki nakittautuneet poistetaan nakista
 
 # Authentication messages
-auth.error.email.not.found=T\u00E4ll\u00E4 s\u00E4hk\u00F6postiosoitteella ei l\u00F6ydy k\u00E4ytt\u00E4j\u00E4\u00E4.
 auth.message.reset.email.sent=Salasanan palautusohjeet on l\u00E4hetetty s\u00E4hk\u00F6postiisi.
 auth.error.token.invalid=Virheellinen tai vanhentunut salasanan palautuslinkki.
 auth.error.passwords.dont.match=Salasanat eiv\u00E4t t\u00E4sm\u00E4\u00E4.
@@ -227,12 +226,8 @@ auth.error.too.many.reset.attempts=Liian monta salasanan palautusyrityst\u00E4. 
 
 # Form labels
 auth.form.label.email=S\u00E4hk\u00F6postiosoite
-auth.form.label.password=Salasana
 auth.form.label.password.confirm=Vahvista salasana
 auth.form.label.password.new=Uusi salasana
-
-# Button labels
-auth.button.back.to.login=Takaisin kirjautumiseen
 
 # Auth page titles
 auth.title.forgot.password=Unohtunut salasana
@@ -240,7 +235,6 @@ auth.title.reset.password=Aseta uusi salasana
 
 # Auth form labels and help texts
 auth.form.email.help=Sy\u00F6t\u00E4 rekister\u00F6ity s\u00E4hk\u00F6postiosoitteesi
-auth.form.password.help=Salasanan tulee olla v\u00E4hint\u00E4\u00E4n 8 merkki\u00E4 pitk\u00E4 ja sis\u00E4lt\u00E4\u00E4 isoja ja pieni\u00E4 kirjaimia sek\u00E4 numeroita
 auth.form.password.requirements=Salasanan tulee olla v\u00E4hint\u00E4\u00E4n 8 merkki\u00E4 pitk\u00E4.
 
 # Auth buttons
@@ -280,7 +274,7 @@ email.message.verification=<!DOCTYPE html>\
 <div style="max-width: 600px; margin: 0 auto; padding: 20px;">\
     <p>Hei,</p>\
     <p>Kiitos rekister\u00F6itymisest\u00E4si. Vahvista s\u00E4hk\u00F6postiosoitteesi klikkaamalla alla olevaa linkki\u00E4:</p>\
-    <p><a href="{0}" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">{1}/a></p>\
+    <p><a href="{0}" style="background-color: #4CAF50; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;">{0}</a></p>\
     <p>Linkki on voimassa 24 tuntia.</p>\
     <p>Yst\u00E4v\u00E4llisin terveisin,<br>Nakitin-tiimi</p>\
 </div>\
@@ -298,8 +292,8 @@ email.message.password-expiration=<!DOCTYPE html>\
 </body>\
 </html>
 verification.button.resend=L\u00E4het\u00E4 vahvistusviesti uudestaan
-verification.success.message=S\u00E4hk\u00F6posti vahvistettiin onnistuneesti
-verification.error.expired=Vahvistuslinkki on vanhentunut
+verification.success.message=S\u00E4hk\u00F6posti vahvistettiin onnistuneesti.
+verification.error.expired=Vahvistuslinkki on vanhentunut.
 verification.title=S\u00E4hk\u00F6postin vahvistus
 verification.error.unverified=Vahvistamaton s\u00E4hk\u00F6postiosoite
 verification.notification.sent=Vahvistuslinkki on l\u00E4hetetty antamaasi s\u00E4hk\u00F6postiosoitteeseen

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -249,9 +249,9 @@ auth.login.submit=Kirjaudu
 auth.login.forgot-password=Unohditko salasanasi?
 auth.error.email.not.verified=S\u00E4hk\u00F6postiosoitetta ei ole vahvistettu
 
-email.subject.password-reset=Salasanan nollaus
-email.subject.verification=Vahvista s\u00E4hk\u00F6postiosoitteesi
-email.subject.password-expiration=Salasanasi vanhenee pian
+email.subject.password-reset=[Nakitin] Salasanan nollaus
+email.subject.verification=[Nakitin] Vahvista s\u00E4hk\u00F6postiosoitteesi
+email.subject.password-expiration=[Nakitin] Salasanasi vanhenee pian
 
 # Email messages
 email.message.password-reset=<!DOCTYPE html>\

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -20,6 +20,12 @@
                             <button class="delete"></button>
                             <span th:text="${message}">Info message</span>
                         </div>
+                        <div th:if="${param.verificationSent}" class="notification is-info"
+                             th:text="#{verification.notification.sent}">
+                        </div>
+                        <div th:if="${param.error == 'disabled'}" class="notification is-warning"
+                             th:text="#{verification.error.unverified}">
+                        </div>
 
                         <form th:action="@{/login}" method="post">
                             <div class="field">

--- a/src/main/resources/templates/auth/verification-result.html
+++ b/src/main/resources/templates/auth/verification-result.html
@@ -8,13 +8,13 @@
     <div class="container">
         <div class="columns is-centered">
             <div class="column is-half">
-                <h1 class="title has-text-centered" th:text="#{verification.title}">Sähköpostin vahvistus</h1>
+                <h1 class="title has-text-centered" th:text="#{verification.title}"></h1>
                 
                 <div th:class="${success ? 'notification is-success' : 'notification is-warning'}"
-                     th:text="${success ? #{verification.success.message} : #{verification.error.expired}}">
+                     th:text="#{${success ? 'verification.success.message' : 'verification.error.expired'}}">
                 </div>
                 
-                <div th:if="${!success}" class="box">
+                <div th:if="${!success && verificationStatus == T(fi.asteriski.nakitin.dto.VerificationStatus).EXPIRED}" class="box">
                     <form th:action="@{/resend-verification}" method="post">
                         <input type="hidden" name="email" th:value="${email}"/>
                         <div class="field">

--- a/src/main/resources/templates/auth/verification-result.html
+++ b/src/main/resources/templates/auth/verification-result.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="fi" data-theme="dark" class="has-navbar-fixed-top">
+<head th:replace="~{fragments/header :: header}"></head>
+<body>
+<nav th:replace="~{fragments/navbar :: navbar}"></nav>
+
+<section class="section">
+    <div class="container">
+        <div class="columns is-centered">
+            <div class="column is-half">
+                <h1 class="title has-text-centered" th:text="#{verification.title}">Sähköpostin vahvistus</h1>
+                
+                <div th:class="${success ? 'notification is-success' : 'notification is-warning'}"
+                     th:text="${success ? #{verification.success.message} : #{verification.error.expired}}">
+                </div>
+                
+                <div th:if="${!success}" class="box">
+                    <form th:action="@{/resend-verification}" method="post">
+                        <input type="hidden" name="email" th:value="${email}"/>
+                        <div class="field">
+                            <div class="control">
+                                <button class="button is-link is-fullwidth" type="submit" 
+                                        th:text="#{verification.button.resend}">
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+                
+                <div class="has-text-centered mt-5">
+                    <a href="/login" class="button is-light" th:text="#{form.button.label.login}">
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<script th:src="@{/js/nakitin.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/profileColumns.html
+++ b/src/main/resources/templates/fragments/profileColumns.html
@@ -10,7 +10,7 @@
             <div class="message-header">
                 <p th:text="#{profile.label.update.success.title}"></p>
             </div>
-            <div class="message-body" th:text="#{profile.label.update.success.text}">
+            <div class="message-body" th:text="#{profile.label.update.success.text} + ' ' + #{${verify ? 'profile.label.update.success.updateEmail' : 'profile.label.update.success.empty'}}">
             </div>
         </article>
         <div class="block">


### PR DESCRIPTION
User's email address is now verified when signing up and when user changes it. 

If new user account is not verified it is deleted after verification token expires.

If email change is not verified before token expires user's email is not changed. User's old email address continues to be used.