### PR TITLE
Add user account deletion functionality

### DIFF
--- a/src/main/java/fi/asteriski/nakitin/controller/UserController.java
+++ b/src/main/java/fi/asteriski/nakitin/controller/UserController.java
@@ -7,12 +7,14 @@ package fi.asteriski.nakitin.controller;
 import static fi.asteriski.nakitin.controller.ControllerHelper.setCommonUserAttributes;
 import static fi.asteriski.nakitin.utils.Constants.*;
 
+import fi.asteriski.nakitin.dto.DeleteForm;
 import fi.asteriski.nakitin.dto.PasswordForm;
 import fi.asteriski.nakitin.dto.SignupForm;
 import fi.asteriski.nakitin.dto.UserDto;
 import fi.asteriski.nakitin.entity.UserEntity;
 import fi.asteriski.nakitin.service.*;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.Locale;
 import java.util.Objects;
@@ -20,6 +22,8 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.springframework.context.MessageSource;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -82,6 +86,7 @@ public class UserController {
         model.addAttribute(
                 MODEL_LABEL_USER_PASSWORD_FORM,
                 PasswordForm.builder().userId(loggedInUser.getId()).build());
+        model.addAttribute(MODEL_LABEL_USER_IS_THE_ONLY_ADMIN, userService.userIsTheOnlyAdmin(loggedInUser.getId()));
 
         return "profile";
     }
@@ -100,6 +105,7 @@ public class UserController {
             model.addAttribute(MODEL_LABEL_USERS_TASKS, eventTaskService.fetchUsersEventTasks(user));
             model.addAttribute(MODEL_LABEL_USER, userService.fetchUserDetails(user.getId()));
             model.addAttribute(MODEL_LABEL_FAILED, true);
+            model.addAttribute(MODEL_LABEL_USER_IS_THE_ONLY_ADMIN, userService.userIsTheOnlyAdmin(user.getId()));
             return "profile";
         }
         userDto.setId(user.getId());
@@ -235,6 +241,43 @@ public class UserController {
 
         model.addAttribute(MODEL_LABEL_USER_IS_LOGGED_IN, false);
         return "auth/login";
+    }
+
+    @GetMapping("/profile/remove-user")
+    public String showRemoveUserConfirmationPage(UUID id, Model model, @AuthenticationPrincipal UserEntity user) {
+        setCommonUserAttributes(model, user);
+        model.addAttribute(MODEL_LABEL_USER, userService.fetchUserById(id));
+        model.addAttribute(MODEL_LABEL_USER_IS_THE_ONLY_ADMIN, userService.userIsTheOnlyAdmin(user.getId()));
+        model.addAttribute(MODEL_LABEL_DELETE_FORM, DeleteForm.builder().id(id).build());
+
+        return "deleteUserConfirmation";
+    }
+
+    @PostMapping("/profile/remove-user")
+    public String removeUser(
+            @Valid @ModelAttribute(MODEL_LABEL_DELETE_FORM) DeleteForm deleteUserForm,
+            BindingResult result,
+            Model model,
+            @AuthenticationPrincipal UserEntity user,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        if (result.hasErrors()) {
+            setCommonUserAttributes(model, user);
+            model.addAttribute(MODEL_LABEL_USER, userService.fetchUserById(deleteUserForm.id()));
+            model.addAttribute(MODEL_LABEL_USER_IS_THE_ONLY_ADMIN, userService.userIsTheOnlyAdmin(user.getId()));
+            model.addAttribute(MODEL_LABEL_USER_IS_ORGANISATION_ADMIN, user.isOrganisationAdmin());
+            model.addAttribute(MODEL_LABEL_USER_IS_ADMIN, user.isAdmin());
+            model.addAttribute(MODEL_LABEL_DELETE_FORM, deleteUserForm);
+            return "deleteUserConfirmation";
+        }
+
+        userService.deleteUser(deleteUserForm.id());
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null) {
+            new SecurityContextLogoutHandler().logout(request, response, auth);
+        }
+
+        return "redirect:/success?from=remove-user";
     }
 
     private void addCustomErrorIfNeeded(BindingResult result, Model model) {

--- a/src/main/java/fi/asteriski/nakitin/dto/UserDto.java
+++ b/src/main/java/fi/asteriski/nakitin/dto/UserDto.java
@@ -34,6 +34,7 @@ public final class UserDto {
 
     public static UserDto fromUserDetailsProjection(UserDetailsProjection userDetailsProjection) {
         return builder()
+                .id(userDetailsProjection.getId())
                 .username(userDetailsProjection.getUsername())
                 .firstName(userDetailsProjection.getFirstName())
                 .lastName(userDetailsProjection.getLastName())

--- a/src/main/java/fi/asteriski/nakitin/entity/UserEntity.java
+++ b/src/main/java/fi/asteriski/nakitin/entity/UserEntity.java
@@ -6,6 +6,7 @@ package fi.asteriski.nakitin.entity;
 
 import static fi.asteriski.nakitin.entity.UserRole.*;
 
+import fi.asteriski.nakitin.dto.OrganizationDto;
 import fi.asteriski.nakitin.dto.UserDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
@@ -220,5 +221,9 @@ public class UserEntity implements UserDetails {
 
     public boolean isEmailVerified() {
         return emailVerified;
+    }
+
+    public boolean isUserInOrganization(OrganizationDto organization) {
+        return organizations.stream().anyMatch(org -> Objects.equals(org.getId(), organization.id()));
     }
 }

--- a/src/main/java/fi/asteriski/nakitin/repo/projection/UserDetailsProjection.java
+++ b/src/main/java/fi/asteriski/nakitin/repo/projection/UserDetailsProjection.java
@@ -4,7 +4,11 @@ Licenced under EUPL-1.2 or later.
  */
 package fi.asteriski.nakitin.repo.projection;
 
+import java.util.UUID;
+
 public interface UserDetailsProjection {
+    UUID getId();
+
     String getUsername();
 
     String getFirstName();

--- a/src/main/java/fi/asteriski/nakitin/service/UserService.java
+++ b/src/main/java/fi/asteriski/nakitin/service/UserService.java
@@ -55,6 +55,9 @@ public class UserService implements UserDetailsService {
     @NonNull
     private final EmailService emailService;
 
+    @NonNull
+    private final EventTaskService eventTaskService;
+
     @Value("${fi.asteriski.config.maxPasswordAgeInDays}")
     private Long maxPasswordAgeInDays;
 
@@ -365,5 +368,21 @@ public class UserService implements UserDetailsService {
 
     public void enableUser(UUID id) {
         userDao.enableUser(id);
+    }
+
+    @Transactional
+    public void deleteUser(UUID id) {
+        final var user = userDao.fetchUsersByIds(List.of(id)).getFirst();
+
+        handleEventTasks(user);
+
+        deleteUser(user);
+    }
+
+    private void handleEventTasks(UserEntity user) {
+        var taskIds = user.getEventTasks().stream().map(EventTaskEntity::getId).toList();
+        if (!taskIds.isEmpty()) {
+            eventTaskService.fetchEventTasksById(taskIds).forEach(user::removeEventTask);
+        }
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -50,6 +50,8 @@ success.deleteEvent.title=Tapahtuman poisto onnistui
 success.deleteEvent.text=Tapahtuma poistettiin onnistuneesti.
 success.deleteTask.title=Poisto onnistui
 success.deleteTask.text=Nakki poistettiin onnistuneesti
+success.deleteUser.title=Poisto onnistui
+success.deleteUser.text=K\u00E4ytt\u00E4j\u00E4tunnuksesi poistettiin onnistuneesti.
 
 profile.label.title.organizations=Yhdistykset
 profile.label.title.statistics=Tilastot
@@ -68,6 +70,9 @@ profile.label.update.success.text=Tiedot p\u00E4ivitettiin onnistuneesti.
 # Note: these are in use in the profile.html template.
 profile.label.update.success.updateEmail=Vaihtamasi s\u00E4hk\u00F6postiosoite pit\u00E4\u00E4 verifioida. Antamaasi osoitteeseen on l\u00E4hetetty vahvistusviesti.
 profile.label.update.success.empty=
+profile.label.delete.notPossible.orgAdmin=Olet yhden tai useamman j\u00E4rjest\u00F6n admin.<br/>Vain Nakittimen admin voi poistaa tunnuksesi. Ota yhteytt\u00E4 Nakittimen adminiin.
+profile.label.delete.notPossible.onlyAdmin=Nakittimen ainoan admin k\u00E4ytt\u00E4j\u00E4n poistaminen ei ole mahdollista.<br/>Mik\u00E4li haluat poistaa t\u00E4m\u00E4n tunnuksen, luo ensin uusi admin k\u00E4ytt\u00E4j\u00E4 k\u00E4ytt\u00E4j\u00E4hallinnan kautta.<br/>T\u00E4m\u00E4n j\u00E4lkeen voit poistaa t\u00E4m\u00E4n tunnuksen k\u00E4ytt\u00E4j\u00E4hallinnan kautta.
+profile.label.delete.notPossible.admin=Nakittimen admin k\u00E4ytt\u00E4j\u00E4n voi poistaa ainoastaan k\u00E4ytt\u00E4j\u00E4hallinnan kautta.
 
 form.button.label.sign-up=Rekister\u00F6idy
 form.button.label.login=Kirjaudu sis\u00E4\u00E4n
@@ -76,6 +81,7 @@ form.button.label.profile=Omat tiedot
 form.button.label.new-event=Lis\u00E4\u00E4 tapahtuma
 form.button.label.edit-event=Muokkaa tapahtumaa
 form.button.label.delete-event=Poista tapahtuma
+form.button.label.delete-user=Poista k\u00E4ytt\u00E4j\u00E4si
 form.button.label.edit=Muokkaa
 form.button.label.delete=Poista
 form.button.label.reset=Tyhjenn\u00E4

--- a/src/main/resources/templates/deleteUserConfirmation.html
+++ b/src/main/resources/templates/deleteUserConfirmation.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="fi" data-theme="dark" class="has-navbar-fixed-top">
+<head th:replace="~{fragments/header.html :: header}">
+</head>
+<body>
+<nav th:replace="~{fragments/navbar.html  ::  navbar}"></nav>
+<div class="columns is-gapless">
+    <div class="column is-4 is-desktop"></div>
+    <div class="column">
+        <div th:if="${user.isAdmin() && userIsTheOnlyAdmin}" class="content">
+            <p class="title" th:text="#{admin.deleteUser.cannotRemoveSingleAdmin}"></p>
+            <a th:href="@{/profile}" th:text="#{admin.deleteUser.back}"></a>
+        </div>
+        <div th:unless="${user.isAdmin() && userIsTheOnlyAdmin}" class="content">
+            <h1 class="title has-text-centered" th:text="#{admin.deleteUser.title}"></h1>
+            <p th:text="#{admin.deleteUser.text.p1}"></p>
+            <span th:text="#{admin.label.usersName} + ' ' + ${user.firstName} + ' ' + ${user.lastName}"></span><br/>
+            <span th:text="#{admin.label.usersUserName} + ' ' + ${user.username}"></span><br/>
+            <span th:text="#{admin.label.usersEmail} + ' ' + ${user.email}"></span><br/><br/>
+
+            <p th:text="#{admin.deleteUser.text.p3}"></p>
+            <ul>
+                <li th:text="#{admin.deleteUser.text.tasks}"></li>
+            </ul>
+            <p th:utext="#{deleteConfirmation.text}"></p>
+            <form th:action="@{/profile/remove-user}" method="post" th:object="${deleteForm}">
+                <input type="hidden" th:field="*{id}" name="userId" th:value="${user.id}"/>
+                <div class="field is-grouped is-left">
+                    <p class="control">
+                        <input type="submit" th:value="#{form.button.label.delete}" class="button is-danger">
+                    </p>
+                    <p class="control">
+                        <a th:href="@{/profile}" th:text="#{form.button.label.back}" class="button is-primary"></a>
+                    </p>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="column is-4 is-desktop"></div>
+</div>
+<script th:src="@{/js/nakitin.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/profileColumns.html
+++ b/src/main/resources/templates/fragments/profileColumns.html
@@ -112,7 +112,17 @@
                         </div>
                     </div>
                 </div>
-            </div>
+            </div><br/><br/>
+            <a class="button is-danger" th:if="${!userIsTheOnlyAdmin && !userIsOrganisationAdmin}" th:text="#{form.button.label.delete-user}" th:href="@{/profile/remove-user(id=${user.id})}"></a>
+            <article class="message is-warning" th:if="${userIsOrganisationAdmin}">
+                <div class="message-body" th:utext="#{profile.label.delete.notPossible.orgAdmin}"></div>
+            </article>
+            <article class="message is-warning" th:if="${userIsTheOnlyAdmin}">
+                <div class="message-body" th:utext="#{profile.label.delete.notPossible.onlyAdmin}"></div>
+            </article>
+            <article class="message is-warning" th:if="${!userIsTheOnlyAdmin && userIsAdmin}">
+                <div class="message-body" th:text="#{profile.label.delete.notPossible.admin}"></div>
+            </article>
         </div>
     </div>
     <div class="column">

--- a/src/main/resources/templates/fragments/successColumns.html
+++ b/src/main/resources/templates/fragments/successColumns.html
@@ -8,9 +8,11 @@
             <div class="message-header">
                 <p th:if="${from == 'signup'}" th:text="#{success.register.title}"></p>
                 <p th:if="${from == 'event-delete'}" th:text="#{success.deleteEvent.title}"></p>
+                <p th:if="${from == 'remove-user'}" th:text="#{success.deleteUser.title}"></p>
             </div>
             <div class="message-body" th:if="${from == 'signup'}" th:text="#{success.register.text}"></div>
             <div class="message-body" th:if="${from == 'event-delete'}" th:text="#{success.deleteEvent.text}"></div>
+            <div class="message-body" th:if="${from == 'remove-user'}" th:text="#{success.deleteUser.text}"></div>
         </article>
     </div>
 </div>


### PR DESCRIPTION
Implemented the ability for users to delete their accounts. Only standard users have the ability to delete their own accounts. If a user is an organization admin or super admin, only a super admin can delete that account with the exception that the only super admin account cannot be deleted.